### PR TITLE
Replanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 ./CMakeLists.txt
 /CMakeLists.txt
 .vscode/
+*.bag

--- a/infrastructure/interface/include/interface/mushr_translation.hpp
+++ b/infrastructure/interface/include/interface/mushr_translation.hpp
@@ -16,8 +16,8 @@ inline void translate_msg(prx_models::MushrPlan& mushr_plan, const ml4kp_bridge:
   {
     const ml4kp_bridge::PlanStep plan_step{ plan.steps[i] };
     // copy(mushr_plan.controls[i], plan_step.control.state);
-    mushr_plan.controls[i].steering_angle.data = plan_step.control.point[0].data;
-    mushr_plan.controls[i].velocity.data = plan_step.control.point[1].data;
+    mushr_plan.controls[i].velocity.data = plan_step.control.point[0].data;
+    mushr_plan.controls[i].steering_angle.data = plan_step.control.point[1].data;
     mushr_plan.durations[i] = plan.steps[i].duration;
   }
 }

--- a/infrastructure/ml4kp_bridge/CMakeLists.txt
+++ b/infrastructure/ml4kp_bridge/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(ml4kp_bridge)
 set(CMAKE_CXX_STANDARD 17)
+add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/infrastructure/ml4kp_bridge/include/ml4kp_bridge/plan_bridge.hpp
+++ b/infrastructure/ml4kp_bridge/include/ml4kp_bridge/plan_bridge.hpp
@@ -45,10 +45,7 @@ inline void copy(prx::plan_t& plan, const ml4kp_bridge::PlanStamped& msg)
 inline void add_zero_control(prx::plan_t& plan)
 {
   plan.append_onto_back(0.0);
-  for (unsigned i = 0; i < plan.back().control->get_dim(); ++i)
-  {
-    plan.back().control->at(i) = 0.0;
-  }
+  Vec(plan.back().control) = Eigen::VectorXd::Zero(plan.back().control->get_dim());
 }
 
 }  // namespace ml4kp_bridge

--- a/infrastructure/ml4kp_bridge/include/ml4kp_bridge/plan_bridge.hpp
+++ b/infrastructure/ml4kp_bridge/include/ml4kp_bridge/plan_bridge.hpp
@@ -42,4 +42,13 @@ inline void copy(prx::plan_t& plan, const ml4kp_bridge::PlanStamped& msg)
   copy(plan, msg.plan);
 }
 
+inline void add_zero_control(prx::plan_t& plan)
+{
+  plan.append_onto_back(0.0);
+  for (unsigned i = 0; i < plan.back().control->get_dim(); ++i)
+  {
+    plan.back().control->at(i) = 0.0;
+  }
+}
+
 }  // namespace ml4kp_bridge

--- a/infrastructure/ml4kp_bridge/include/ml4kp_bridge/plan_bridge.hpp
+++ b/infrastructure/ml4kp_bridge/include/ml4kp_bridge/plan_bridge.hpp
@@ -42,9 +42,9 @@ inline void copy(prx::plan_t& plan, const ml4kp_bridge::PlanStamped& msg)
   copy(plan, msg.plan);
 }
 
-inline void add_zero_control(prx::plan_t& plan)
+inline void add_zero_control(prx::plan_t& plan, double duration = 0.0)
 {
-  plan.append_onto_back(0.0);
+  plan.append_onto_back(duration);
   Vec(plan.back().control) = Eigen::VectorXd::Zero(plan.back().control->get_dim());
 }
 

--- a/infrastructure/prx_models/CMakeLists.txt
+++ b/infrastructure/prx_models/CMakeLists.txt
@@ -113,7 +113,7 @@ generate_messages(
 catkin_package(
  INCLUDE_DIRS include
 #  LIBRARIES mujoco
- CATKIN_DEPENDS geometry_msgs roscpp std_msgs message_runtime
+ CATKIN_DEPENDS geometry_msgs roscpp std_msgs message_runtime ml4kp_bridge
 #  DEPENDS system_lib
 )
 

--- a/infrastructure/prx_models/include/prx_models/mj_mushr.hpp
+++ b/infrastructure/prx_models/include/prx_models/mj_mushr.hpp
@@ -2,6 +2,7 @@
 #include "eigen3/Eigen/Dense"
 #include "geometry_msgs/Pose2D.h"
 
+#include <ml4kp_bridge/defs.h>
 #include "prx_models/mj_copy.hpp"
 
 #include <mujoco_ros/SensorDataStamped.h>
@@ -32,19 +33,15 @@ struct mushr_t
 template <typename Ctrl>
 inline void copy(Ctrl ctrl_out, const prx_models::MushrControl& msg)
 {
-  // ctrl_out[0] = msg.steering_angle.data;
-  // ctrl_out[1] = msg.velocity.data;
-  ctrl_out[0] = msg.velocity.data;
-  ctrl_out[1] = msg.steering_angle.data;
+  ctrl_out[0] = msg.steering_angle.data;
+  ctrl_out[1] = msg.velocity.data;
 }
 
 template <typename Ctrl>
 inline void copy(prx_models::MushrControl& msg, const Ctrl& ctrl)
 {
-  // msg.steering_angle.data = ctrl[0];
-  // msg.velocity.data = ctrl[1];
-  msg.velocity.data = ctrl[0];
-  msg.steering_angle.data = ctrl[1];
+  msg.steering_angle.data = ctrl[0];
+  msg.velocity.data = ctrl[1];
 }
 
 template <typename SensorData>
@@ -66,8 +63,10 @@ inline void copy(StateSpacePoint& state, const prx_models::MushrObservation& msg
   state->at(1) = msg.pose.position.y;
   Eigen::Quaterniond quat = Eigen::Quaterniond(msg.pose.orientation.w, msg.pose.orientation.x, msg.pose.orientation.y,
                                                msg.pose.orientation.z);
-  Eigen::Vector3d euler = quat.toRotationMatrix().eulerAngles(0, 1, 2);
+  // Eigen::Vector3d euler = quat.toRotationMatrix().eulerAngles(0, 1, 2);
+  Eigen::Vector3d euler = prx::quaternion_to_euler(quat);
   state->at(2) = euler[2];
+  // ROS_WARN("Copying observation: %f, %f, %f", state->at(0), state->at(1), state->at(2));
 }
 
 template <typename StateSpacePoint>

--- a/infrastructure/prx_models/include/prx_models/mj_mushr.hpp
+++ b/infrastructure/prx_models/include/prx_models/mj_mushr.hpp
@@ -32,15 +32,19 @@ struct mushr_t
 template <typename Ctrl>
 inline void copy(Ctrl ctrl_out, const prx_models::MushrControl& msg)
 {
-  ctrl_out[0] = msg.steering_angle.data;
-  ctrl_out[1] = msg.velocity.data;
+  // ctrl_out[0] = msg.steering_angle.data;
+  // ctrl_out[1] = msg.velocity.data;
+  ctrl_out[0] = msg.velocity.data;
+  ctrl_out[1] = msg.steering_angle.data;
 }
 
 template <typename Ctrl>
 inline void copy(prx_models::MushrControl& msg, const Ctrl& ctrl)
 {
-  msg.steering_angle.data = ctrl[0];
-  msg.velocity.data = ctrl[1];
+  // msg.steering_angle.data = ctrl[0];
+  // msg.velocity.data = ctrl[1];
+  msg.velocity.data = ctrl[0];
+  msg.steering_angle.data = ctrl[1];
 }
 
 template <typename SensorData>
@@ -72,5 +76,7 @@ inline void copy(StateSpacePoint& state, const geometry_msgs::Pose2D& msg)
   state->at(0) = msg.x;
   state->at(1) = msg.y;
   state->at(2) = msg.theta;
+  state->at(3) = 0.0;
+  ROS_WARN("Setting current velocity to 0.0");
 }
 }  // namespace prx_models

--- a/infrastructure/prx_models/models/friction_floors/friction_floor_uniform.xml
+++ b/infrastructure/prx_models/models/friction_floors/friction_floor_uniform.xml
@@ -10,7 +10,7 @@
     <map znear="0.001" />
   </visual>
   <worldbody>
-    <geom contype="1" friction="1 0 0" name="floor0" pos="0 0 0" euler="0 0 0" size="100 100 0.01" type="box" material="matplane0" condim="6"/> 
+    <geom contype="1" friction="1 0 0.01" name="floor0" pos="0 0 0" euler="0 0 0" size="100 100 0.01" type="box" material="matplane0" condim="6"/> 
     <!-- <geom contype="1" friction="1 0 0.001" name="floor2" pos="-2 0 0" euler="0 0 0" size="1 1 0.1" type="plane" material="matplane" condim="6"/>  -->
 
 

--- a/infrastructure/prx_models/package.xml
+++ b/infrastructure/prx_models/package.xml
@@ -55,6 +55,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>ml4kp_bridge</build_depend>
 
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
@@ -64,6 +65,7 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>message_runtime</exec_depend>
+  <exec_depend>ml4kp_bridge</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/infrastructure/prx_models/srv/mushr/MushrPlanner.srv
+++ b/infrastructure/prx_models/srv/mushr/MushrPlanner.srv
@@ -1,7 +1,7 @@
 prx_models/MushrObservation current_observation
 geometry_msgs/Pose2D goal_configuration
 std_msgs/Duration planning_duration
-std_msgs/Duration execution_duration
+std_msgs/Bool first_cycle 
 ---
 ml4kp_bridge/Plan output_plan
 uint8 TYPE_SUCCESS=1

--- a/infrastructure/prx_models/srv/mushr/MushrPlanner.srv
+++ b/infrastructure/prx_models/srv/mushr/MushrPlanner.srv
@@ -2,8 +2,10 @@ prx_models/MushrObservation current_observation
 geometry_msgs/Pose2D goal_configuration
 std_msgs/Duration planning_duration
 std_msgs/Bool first_cycle 
+std_msgs/Bool return_trajectory
 ---
 ml4kp_bridge/Plan output_plan
+ml4kp_bridge/Trajectory output_trajectory
 uint8 TYPE_SUCCESS=1
 uint8 TYPE_FAILURE=0
 uint8 planner_output

--- a/infrastructure/prx_models/srv/mushr/MushrPlanner.srv
+++ b/infrastructure/prx_models/srv/mushr/MushrPlanner.srv
@@ -1,6 +1,7 @@
 prx_models/MushrObservation current_observation
 geometry_msgs/Pose2D goal_configuration
 std_msgs/Duration planning_duration
+std_msgs/Duration execution_duration
 ---
 ml4kp_bridge/Plan output_plan
 uint8 TYPE_SUCCESS=1

--- a/motion_planning/include/motion_planning/planner_client.hpp
+++ b/motion_planning/include/motion_planning/planner_client.hpp
@@ -42,11 +42,12 @@ public:
     _obs_received = true;
   }
 
-  void call_service(const geometry_msgs::Pose2D& goal_configuration, const std_msgs::Float64& goal_radius, double planning_duration = 1.0)
+  void call_service(const geometry_msgs::Pose2D& goal_configuration, const std_msgs::Float64& goal_radius, double planning_duration = 1.0,
+                    double execution_duration = 60.0)
   {
     while (!_obs_received)
     {
-      ROS_INFO("Waiting for observation");
+      ROS_WARN("Waiting for observation");
       ros::Duration(0.1).sleep();
     }
     ROS_INFO("Calling planner service");
@@ -58,14 +59,15 @@ public:
              _service.request.current_observation.pose.orientation.x,
              _service.request.current_observation.pose.orientation.y,
              _service.request.current_observation.pose.orientation.z);
-    _service.request.planning_duration.data = ros::Duration(1.0);
+    _service.request.planning_duration.data = ros::Duration(planning_duration);
+    _service.request.execution_duration.data = ros::Duration(execution_duration);
     _service.request.goal_configuration = goal_configuration;
     if (_service_client.call(_service))
     {
-      ROS_INFO("Service call successful");
+      ROS_DEBUG("Service call successful");
       if (_service.response.planner_output == Service::Response::TYPE_SUCCESS)
       {
-        ROS_INFO("Publishing plan");
+        ROS_DEBUG("Publishing plan");
         _plan_publisher.publish(_service.response.output_plan);
       }
       else

--- a/motion_planning/include/motion_planning/planner_client.hpp
+++ b/motion_planning/include/motion_planning/planner_client.hpp
@@ -4,26 +4,27 @@
 
 namespace mj_ros
 {
-template <typename Service, typename Observation, typename Plan>
+template <typename Service, typename Observation>
 class planner_client_t
 {
 private:
   ros::ServiceClient _service_client;
   ros::Subscriber _obs_subscriber;
-  ros::Publisher _plan_publisher;
+  ros::Publisher _plan_publisher, _traj_publisher;
   Service _service;
   Observation _most_recent_observation;
-  bool _obs_received{ false };
+  bool _obs_received{ false }, _publish_trajectory{ false };
   double _preprocess_start_time, _query_fulfill_end_time;
 
 public:
-  planner_client_t(ros::NodeHandle& nh)
+  planner_client_t(ros::NodeHandle& nh, bool publish_trajectory = false) : _publish_trajectory(publish_trajectory)
   {
     const std::string root{ ros::this_node::getNamespace() };
     const std::string service_name{ root + "/planner_service" };
     _service_client = nh.serviceClient<Service>(service_name);
     _obs_subscriber = nh.subscribe(root + "/pose", 1000, &planner_client_t::observation_callback, this);
-    _plan_publisher = nh.advertise<Plan>(root + "/ml4kp_plan", 1000, true);
+    _plan_publisher = nh.advertise<ml4kp_bridge::Plan>(root + "/ml4kp_plan", 1000, true);
+    _traj_publisher = nh.advertise<ml4kp_bridge::Trajectory>(root + "/ml4kp_traj", 1000, true);
   }
 
   double get_preprocess_time() const
@@ -62,6 +63,7 @@ public:
     _service.request.planning_duration.data = ros::Duration(planning_duration);
     _service.request.first_cycle.data = first_cycle;
     _service.request.goal_configuration = goal_configuration;
+    _service.request.return_trajectory.data = _publish_trajectory;
     if (_service_client.call(_service))
     {
       ROS_DEBUG("Service call successful");
@@ -69,6 +71,10 @@ public:
       {
         ROS_DEBUG("Publishing plan");
         _plan_publisher.publish(_service.response.output_plan);
+        if (_publish_trajectory)
+        {
+          _traj_publisher.publish(_service.response.output_trajectory);
+        }
       }
       else
       {

--- a/motion_planning/include/motion_planning/planner_client.hpp
+++ b/motion_planning/include/motion_planning/planner_client.hpp
@@ -43,7 +43,7 @@ public:
   }
 
   void call_service(const geometry_msgs::Pose2D& goal_configuration, const std_msgs::Float64& goal_radius, double planning_duration = 1.0,
-                    double execution_duration = 60.0)
+                    bool first_cycle = true)
   {
     while (!_obs_received)
     {
@@ -60,7 +60,7 @@ public:
              _service.request.current_observation.pose.orientation.y,
              _service.request.current_observation.pose.orientation.z);
     _service.request.planning_duration.data = ros::Duration(planning_duration);
-    _service.request.execution_duration.data = ros::Duration(execution_duration);
+    _service.request.first_cycle.data = first_cycle;
     _service.request.goal_configuration = goal_configuration;
     if (_service_client.call(_service))
     {

--- a/motion_planning/include/motion_planning/planner_client.hpp
+++ b/motion_planning/include/motion_planning/planner_client.hpp
@@ -50,10 +50,10 @@ public:
       ROS_WARN("Waiting for observation");
       ros::Duration(0.1).sleep();
     }
-    ROS_INFO("Calling planner service");
+    ROS_DEBUG("Calling planner service");
     _preprocess_start_time = ros::Time::now().toSec();
     _service.request.current_observation = _most_recent_observation;
-    ROS_INFO("Current observation: %f, %f, %f, %f, %f, %f", _service.request.current_observation.pose.position.x,
+    ROS_DEBUG("Current observation: %f, %f, %f, %f, %f, %f", _service.request.current_observation.pose.position.x,
              _service.request.current_observation.pose.position.y,
              _service.request.current_observation.pose.orientation.w,
              _service.request.current_observation.pose.orientation.x,

--- a/motion_planning/include/motion_planning/planner_service.hpp
+++ b/motion_planning/include/motion_planning/planner_service.hpp
@@ -15,6 +15,7 @@ private:
   QueryPtr _query;
   SpecPtr _spec;
   Service _service;
+  double _preprocess_end_time, _query_fulfill_start_time;
 
 public:
   planner_service_t(ros::NodeHandle& nh, PlannerPtr planner, SpecPtr spec, QueryPtr query)
@@ -23,6 +24,16 @@ public:
     const std::string root{ ros::this_node::getNamespace() };
     const std::string service_name{ root + "/planner_service" };
     _service_server = nh.advertiseService(service_name, &planner_service_t::service_callback, this);
+  }
+
+  double get_preprocess_time() const
+  {
+    return _preprocess_end_time;
+  }
+
+  double get_query_fulfill_time() const
+  {
+    return _query_fulfill_start_time;
   }
 
   bool service_callback(typename Service::Request& request, typename Service::Response& response)
@@ -36,7 +47,9 @@ public:
     _planner->link_and_setup_spec(_spec);
     _planner->preprocess();
     _planner->link_and_setup_query(_query);
+    _preprocess_end_time = ros::Time::now().toSec();
     _planner->resolve_query(&checker);
+    _query_fulfill_start_time = ros::Time::now().toSec();
     _planner->fulfill_query();
 
     if (_query->solution_traj.size() > 0)

--- a/motion_planning/include/motion_planning/replanner_service.hpp
+++ b/motion_planning/include/motion_planning/replanner_service.hpp
@@ -81,7 +81,7 @@ public:
       double execution_time = request.planning_duration.data.toSec();
       step_plan->clear();
       _query->solution_plan.copy_to(0, execution_time, *step_plan);
-      ml4kp_bridge::add_zero_control(*step_plan);
+      // ml4kp_bridge::add_zero_control(*step_plan);
       ml4kp_bridge::copy(response.output_plan, step_plan);
       response.planner_output = Service::Response::TYPE_SUCCESS;
     }

--- a/motion_planning/include/motion_planning/replanner_service.hpp
+++ b/motion_planning/include/motion_planning/replanner_service.hpp
@@ -88,6 +88,8 @@ public:
     else
     {
       ROS_WARN("No solution found");
+      step_plan->clear();
+      ml4kp_bridge::add_zero_control(*step_plan, request.planning_duration.data.toSec());
       response.planner_output = Service::Response::TYPE_FAILURE;
     }
     _planner->reset();

--- a/motion_planning/include/motion_planning/replanner_service.hpp
+++ b/motion_planning/include/motion_planning/replanner_service.hpp
@@ -1,6 +1,4 @@
 #include <ml4kp_bridge/defs.h>
-#include <ml4kp_bridge/plan_bridge.hpp>
-
 #include <prx_models/mj_copy.hpp>
 #include <ros/ros.h>
 
@@ -83,6 +81,10 @@ public:
       _query->solution_plan.copy_to(0, execution_time, *step_plan);
       // ml4kp_bridge::add_zero_control(*step_plan);
       ml4kp_bridge::copy(response.output_plan, step_plan);
+      if (request.return_trajectory.data)
+      {
+        ml4kp_bridge::copy(response.output_trajectory, _query->solution_traj);
+      }
       response.planner_output = Service::Response::TYPE_SUCCESS;
     }
     else

--- a/motion_planning/include/motion_planning/replanner_service.hpp
+++ b/motion_planning/include/motion_planning/replanner_service.hpp
@@ -1,0 +1,112 @@
+#include <ml4kp_bridge/defs.h>
+#include <ml4kp_bridge/plan_bridge.hpp>
+
+#include <prx_models/mj_copy.hpp>
+#include <ros/ros.h>
+
+namespace mj_ros
+{
+template <typename PlannerPtr, typename SpecPtr, typename QueryPtr, typename Service>
+class planner_service_t
+{
+private:
+  ros::ServiceServer _service_server;
+  PlannerPtr _planner;
+  QueryPtr _query;
+  SpecPtr _spec;
+  Service _service;
+  double _preprocess_end_time, _query_fulfill_start_time;
+  double preprocess_timeout, postprocess_timeout;
+
+  prx::plan_t* step_plan;
+  prx::trajectory_t* step_traj;
+
+public:
+  planner_service_t(ros::NodeHandle& nh, PlannerPtr planner, SpecPtr spec, QueryPtr query)
+    : _planner(planner), _query(query), _spec(spec), preprocess_timeout(0.0), postprocess_timeout(0.0)
+  {
+    const std::string root{ ros::this_node::getNamespace() };
+    const std::string service_name{ root + "/planner_service" };
+    _service_server = nh.advertiseService(service_name, &planner_service_t::service_callback, this);
+
+    step_plan = new prx::plan_t(_spec->control_space);
+    step_traj = new prx::trajectory_t(_spec->state_space);
+  }
+
+  void set_preprocess_timeout(double timeout)
+  {
+    preprocess_timeout = timeout;
+  }
+
+  void set_postprocess_timeout(double timeout)
+  {
+    postprocess_timeout = timeout;
+  }
+
+  double get_preprocess_time() const
+  {
+    return _preprocess_end_time;
+  }
+
+  double get_query_fulfill_time() const
+  {
+    return _query_fulfill_start_time;
+  }
+
+  bool service_callback(typename Service::Request& request, typename Service::Response& response)
+  {
+    prx::condition_check_t checker("time", request.planning_duration.data.toSec() - preprocess_timeout - postprocess_timeout);
+
+    prx_models::copy(_query->start_state, request.current_observation);
+    prx_models::copy(_query->goal_state, request.goal_configuration);
+
+    if (!request.first_cycle.data)
+    {
+      step_traj->clear();
+      _spec->propagate(_query->start_state, *step_plan, *step_traj);
+      _spec->state_space->copy_point(_query->start_state, step_traj->back());
+    }
+
+    _planner->link_and_setup_spec(_spec);
+    _planner->preprocess();
+    _planner->link_and_setup_query(_query);
+    _preprocess_end_time = ros::Time::now().toSec();
+    _planner->resolve_query(&checker);
+    _query_fulfill_start_time = ros::Time::now().toSec();
+    _planner->fulfill_query();
+
+    if (_query->solution_traj.size() > 0)
+    {
+      double execution_time = request.first_cycle.data ? request.planning_duration.data.toSec() * 2.0
+                                                  : request.planning_duration.data.toSec();
+      if (execution_time < _query->solution_plan.duration())
+      {
+        double accumulated_duration = 0.0;
+        unsigned index = 0;
+        for (; index < _query->solution_plan.size(); index++)
+        {
+          accumulated_duration += _query->solution_plan[index].duration;
+          if (accumulated_duration > execution_time)
+          {
+            accumulated_duration -= _query->solution_plan[index].duration;
+            break;
+          }
+        }
+        _query->solution_plan.resize(index + 1);
+        _query->solution_plan.back().duration = execution_time - accumulated_duration;
+      }
+      ml4kp_bridge::add_zero_control(_query->solution_plan);
+      ml4kp_bridge::copy(response.output_plan, _query->solution_plan);
+      response.planner_output = Service::Response::TYPE_SUCCESS;
+      ROS_ERROR("Right now, the plan partitioning is not taking place...");
+    }
+    else
+    {
+      ROS_WARN("No solution found");
+      response.planner_output = Service::Response::TYPE_FAILURE;
+    }
+    _planner->reset();
+    return true;
+  }
+};
+}  // namespace mj_ros

--- a/motion_planning/include/motion_planning/single_shot_planner_service.hpp
+++ b/motion_planning/include/motion_planning/single_shot_planner_service.hpp
@@ -53,23 +53,6 @@ public:
 
     if (_query->solution_traj.size() > 0)
     {
-      double execution_time = request.execution_duration.data.toSec();
-      if (execution_time < _query->solution_plan.duration())
-      {
-        double accumulated_duration = 0.0;
-        unsigned index = 0;
-        for (; index < _query->solution_plan.size(); index++)
-        {
-          accumulated_duration += _query->solution_plan[index].duration;
-          if (accumulated_duration > execution_time)
-          {
-            accumulated_duration -= _query->solution_plan[index].duration;
-            break;
-          }
-        }
-        _query->solution_plan.resize(index + 1);
-        _query->solution_plan.back().duration = execution_time - accumulated_duration;
-      }
       ml4kp_bridge::add_zero_control(_query->solution_plan);
       ml4kp_bridge::copy(response.output_plan, _query->solution_plan);
       response.planner_output = Service::Response::TYPE_SUCCESS;

--- a/motion_planning/include/motion_planning/single_shot_planner_service.hpp
+++ b/motion_planning/include/motion_planning/single_shot_planner_service.hpp
@@ -1,6 +1,4 @@
 #include <ml4kp_bridge/defs.h>
-#include <ml4kp_bridge/plan_bridge.hpp>
-
 #include <prx_models/mj_copy.hpp>
 #include <ros/ros.h>
 
@@ -55,6 +53,10 @@ public:
     {
       ml4kp_bridge::add_zero_control(_query->solution_plan);
       ml4kp_bridge::copy(response.output_plan, _query->solution_plan);
+      if (request.return_trajectory.data)
+      {
+        ml4kp_bridge::copy(response.output_trajectory, _query->solution_traj);
+      }
       response.planner_output = Service::Response::TYPE_SUCCESS;
     }
     else

--- a/task_planning/CMakeLists.txt
+++ b/task_planning/CMakeLists.txt
@@ -102,7 +102,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
+ INCLUDE_DIRS include
 #  LIBRARIES mujoco
  CATKIN_DEPENDS roscpp std_msgs message_runtime motion_planning
 #  DEPENDS system_lib

--- a/task_planning/README.md
+++ b/task_planning/README.md
@@ -6,3 +6,4 @@
 - [ ] Add goal radius/goal check to planner query?
 - [ ] Re-planning node
 - [ ] Quality-of-life improvements to bag file processing
+- [ ] Add visualization of the ML4KP-planned trajectory in MuJoCo

--- a/task_planning/README.md
+++ b/task_planning/README.md
@@ -2,8 +2,8 @@
 ## TODOs
 - [x] Enable visualization of the planning goal.
 - [x] Re-planning node
+- [x] Add visualization of the ML4KP-planned trajectory in MuJoCo
 - [ ] Add obstacles to the scene.
 - [ ] Ensure two-way mapping between obstacle yaml files (for ML4KP) and MuJoCo XML files
 - [ ] Add goal radius/goal check to planner query and service call
 - [ ] Quality-of-life improvements to bag file processing
-- [ ] Add visualization of the ML4KP-planned trajectory in MuJoCo

--- a/task_planning/README.md
+++ b/task_planning/README.md
@@ -5,3 +5,4 @@
 - [ ] Ensure two-way mapping between obstacle yaml files (for ML4KP) and MuJoCo XML files
 - [ ] Add goal radius/goal check to planner query?
 - [ ] Re-planning node
+- [ ] Quality-of-life improvements to bag file processing

--- a/task_planning/README.md
+++ b/task_planning/README.md
@@ -4,6 +4,6 @@
 - [x] Re-planning node
 - [ ] Add obstacles to the scene.
 - [ ] Ensure two-way mapping between obstacle yaml files (for ML4KP) and MuJoCo XML files
-- [ ] Add goal radius/goal check to planner query?
+- [ ] Add goal radius/goal check to planner query and service call
 - [ ] Quality-of-life improvements to bag file processing
 - [ ] Add visualization of the ML4KP-planned trajectory in MuJoCo

--- a/task_planning/README.md
+++ b/task_planning/README.md
@@ -1,9 +1,9 @@
 # Task Planning
 ## TODOs
 - [x] Enable visualization of the planning goal.
+- [x] Re-planning node
 - [ ] Add obstacles to the scene.
 - [ ] Ensure two-way mapping between obstacle yaml files (for ML4KP) and MuJoCo XML files
 - [ ] Add goal radius/goal check to planner query?
-- [ ] Re-planning node
 - [ ] Quality-of-life improvements to bag file processing
 - [ ] Add visualization of the ML4KP-planned trajectory in MuJoCo

--- a/task_planning/include/utils.hpp
+++ b/task_planning/include/utils.hpp
@@ -1,0 +1,15 @@
+#include <sstream>
+#include <vector>
+
+template <typename T>
+std::vector<T> string_to_vector(const std::string& s, char delimiter)
+{
+  std::vector<T> tokens;
+  std::string token;
+  std::istringstream tokenStream(s.substr(1, s.size() - 2));
+  while (std::getline(tokenStream, token, delimiter))
+  {
+    tokens.push_back(std::stod(token));
+  }
+  return tokens;
+}

--- a/task_planning/launch/replanning.launch
+++ b/task_planning/launch/replanning.launch
@@ -1,8 +1,7 @@
 <launch> 
     <arg name = "namespace" default = "mushr"/>
     <arg name = "random_seed" default = "0"/>
-    <arg name = "goal_x" default = "3.0"/>
-    <arg name = "goal_y" default = "3.0"/>
+    <arg name = "goal_config" default = "[3.0, 3.0, 0.0]"/>
     <arg name = "planning_cycle_duration" default = "1.0"/>
     <arg name = "preprocess_timeout" default = "0.1" />
     <arg name = "postprocess_timeout" default = "0.1" />
@@ -11,8 +10,7 @@
     <group ns="$(arg namespace)">
         <node pkg="task_planning" name="single_shot_planner" type="$(arg namespace)_replanning" output="screen">
             <param name="random_seed" value="$(arg random_seed)" />
-            <param name="goal_x" value="$(arg goal_x)" />
-            <param name="goal_y" value="$(arg goal_y)" />
+            <param name="goal_config" value="$(arg goal_config)" />
             <param name="planning_cycle_duration" value="$(arg planning_cycle_duration)" />
             <param name="preprocess_timeout" value="$(arg preprocess_timeout)" />
             <param name="postprocess_timeout" value="$(arg postprocess_timeout)" />

--- a/task_planning/launch/replanning.launch
+++ b/task_planning/launch/replanning.launch
@@ -8,7 +8,7 @@
     <arg name = "postprocess_timeout" default = "0.1" />
     <include file="$(find interface)/launch/$(arg namespace)_interface.launch"/>
     <group ns="$(arg namespace)">
-        <node pkg="task_planning" name="single_shot_planner" type="$(arg namespace)_open_loop_planning" output="screen">
+        <node pkg="task_planning" name="single_shot_planner" type="$(arg namespace)_replanning" output="screen">
             <param name="random_seed" value="$(arg random_seed)" />
             <param name="goal_x" value="$(arg goal_x)" />
             <param name="goal_y" value="$(arg goal_y)" />

--- a/task_planning/launch/replanning.launch
+++ b/task_planning/launch/replanning.launch
@@ -1,0 +1,21 @@
+<launch> 
+    <arg name = "namespace" default = "mushr"/>
+    <arg name = "random_seed" default = "0"/>
+    <arg name = "goal_x" default = "3.0"/>
+    <arg name = "goal_y" default = "3.0"/>
+    <arg name = "planning_cycle_duration" default = "1.0"/>
+    <arg name = "preprocess_timeout" default = "0.1" />
+    <arg name = "postprocess_timeout" default = "0.1" />
+    <include file="$(find interface)/launch/$(arg namespace)_interface.launch"/>
+    <group ns="$(arg namespace)">
+        <node pkg="task_planning" name="single_shot_planner" type="$(arg namespace)_open_loop_planning" output="screen">
+            <param name="random_seed" value="$(arg random_seed)" />
+            <param name="goal_x" value="$(arg goal_x)" />
+            <param name="goal_y" value="$(arg goal_y)" />
+            <param name="planning_cycle_duration" value="$(arg planning_cycle_duration)" />
+            <param name="preprocess_timeout" value="$(arg preprocess_timeout)" />
+            <param name="postprocess_timeout" value="$(arg postprocess_timeout)" />
+        </node>
+        <node pkg="rosbag" name="rosbag_record" type="record" args="-a -O $(find task_planning)/data/$(arg namespace).bag"/>
+    </group>
+</launch>

--- a/task_planning/launch/replanning.launch
+++ b/task_planning/launch/replanning.launch
@@ -6,9 +6,8 @@
     <arg name = "preprocess_timeout" default = "0.1" />
     <arg name = "postprocess_timeout" default = "0.1" />
     <arg name = "visualize" default = "false"/>
-    <include file="$(find interface)/launch/$(arg namespace)_interface.launch"/>
     <group ns="$(arg namespace)">
-        <node pkg="task_planning" name="single_shot_planner" type="$(arg namespace)_replanning" output="screen">
+        <node pkg="task_planning" name="replanner" type="$(arg namespace)_replanning" output="screen">
             <param name="random_seed" value="$(arg random_seed)" />
             <param name="goal_config" value="$(arg goal_config)" />
             <param name="planning_cycle_duration" value="$(arg planning_cycle_duration)" />

--- a/task_planning/launch/replanning.launch
+++ b/task_planning/launch/replanning.launch
@@ -6,6 +6,7 @@
     <arg name = "planning_cycle_duration" default = "1.0"/>
     <arg name = "preprocess_timeout" default = "0.1" />
     <arg name = "postprocess_timeout" default = "0.1" />
+    <arg name = "visualize" default = "false"/>
     <include file="$(find interface)/launch/$(arg namespace)_interface.launch"/>
     <group ns="$(arg namespace)">
         <node pkg="task_planning" name="single_shot_planner" type="$(arg namespace)_replanning" output="screen">
@@ -15,6 +16,7 @@
             <param name="planning_cycle_duration" value="$(arg planning_cycle_duration)" />
             <param name="preprocess_timeout" value="$(arg preprocess_timeout)" />
             <param name="postprocess_timeout" value="$(arg postprocess_timeout)" />
+            <param name="visualize" value="$(arg visualize)" />
         </node>
         <node pkg="rosbag" name="rosbag_record" type="record" args="-a -O $(find task_planning)/data/$(arg namespace).bag"/>
     </group>

--- a/task_planning/launch/single_shot.launch
+++ b/task_planning/launch/single_shot.launch
@@ -6,8 +6,7 @@
     <arg name = "random_seed" default = "0"/>
     <arg name = "goal_x" default = "3.0"/>
     <arg name = "goal_y" default = "3.0"/>
-    <arg name = "planning_duration" default = "1.0"/>
-    <arg name = "execution_duration" default = "60.0"/>
+    <arg name = "planning_cycle_duration" default = "1.0"/>
     <include file="$(find interface)/launch/$(arg namespace)_interface.launch"/>
     <group ns="$(arg namespace)">
         <node pkg="task_planning" name="single_shot_planner" type="$(arg namespace)_open_loop_planning" output="screen">
@@ -17,8 +16,7 @@
             <param name="random_seed" value="$(arg random_seed)" />
             <param name="goal_x" value="$(arg goal_x)" />
             <param name="goal_y" value="$(arg goal_y)" />
-            <param name="planning_duration" value="$(arg planning_duration)" />
-            <param name="execution_duration" value="$(arg execution_duration)" />
+            <param name="planning_cycle_duration" value="$(arg planning_cycle_duration)" />
         </node>
         <node pkg="rosbag" name="rosbag_record" type="record" args="-a -O $(find task_planning)/data/$(arg namespace).bag"/>
     </group>

--- a/task_planning/launch/single_shot.launch
+++ b/task_planning/launch/single_shot.launch
@@ -7,7 +7,6 @@
     <arg name = "goal_config" default = "[3.0, 3.0, 0.0]"/>
     <arg name = "planning_cycle_duration" default = "1.0"/>
     <arg name = "visualize" default = "false"/>
-    <include file="$(find interface)/launch/$(arg namespace)_interface.launch"/>
     <group ns="$(arg namespace)">
         <node pkg="task_planning" name="single_shot_planner" type="$(arg namespace)_open_loop_planning" output="screen">
             <param name="traj_file" value="$(arg traj_file)" />

--- a/task_planning/launch/single_shot.launch
+++ b/task_planning/launch/single_shot.launch
@@ -4,8 +4,7 @@
     <arg name = "out_html"  default = "ROS_output.html"/>
     <arg name = "namespace" default = "mushr"/>
     <arg name = "random_seed" default = "0"/>
-    <arg name = "goal_x" default = "3.0"/>
-    <arg name = "goal_y" default = "3.0"/>
+    <arg name = "goal_config" default = "[3.0, 3.0, 0.0]"/>
     <arg name = "planning_cycle_duration" default = "1.0"/>
     <arg name = "visualize" default = "false"/>
     <include file="$(find interface)/launch/$(arg namespace)_interface.launch"/>
@@ -15,8 +14,7 @@
             <param name="plan_file" value="$(arg plan_file)" />
             <param name="out_html"  value="$(arg out_html)" />
             <param name="random_seed" value="$(arg random_seed)" />
-            <param name="goal_x" value="$(arg goal_x)" />
-            <param name="goal_y" value="$(arg goal_y)" />
+            <param name="goal_config" value="$(arg goal_config)" />
             <param name="planning_cycle_duration" value="$(arg planning_cycle_duration)" />
             <param name="visualize" value="$(arg visualize)" />
         </node>

--- a/task_planning/launch/single_shot.launch
+++ b/task_planning/launch/single_shot.launch
@@ -1,6 +1,6 @@
 <launch> 
-    <arg name = "traj_file" default = "traj.txt"/>  
-    <arg name = "plan_file" default = "plan.txt"/>
+    <arg name = "traj_file" default = "ml4kp_traj.txt"/>  
+    <arg name = "plan_file" default = "ml4kp_plan.txt"/>
     <arg name = "out_html"  default = "ROS_output.html"/>
     <arg name = "namespace" default = "mushr"/>
     <arg name = "random_seed" default = "0"/>
@@ -12,5 +12,6 @@
             <param name="out_html"  value="$(arg out_html)" />
             <param name="random_seed" value="$(arg random_seed)" />
         </node>
+        <node pkg="rosbag" name="rosbag_record" type="record" args="-a -O $(find task_planning)/data/$(arg namespace).bag"/>
     </group>
 </launch>

--- a/task_planning/launch/single_shot.launch
+++ b/task_planning/launch/single_shot.launch
@@ -7,6 +7,7 @@
     <arg name = "goal_x" default = "3.0"/>
     <arg name = "goal_y" default = "3.0"/>
     <arg name = "planning_cycle_duration" default = "1.0"/>
+    <arg name = "visualize" default = "false"/>
     <include file="$(find interface)/launch/$(arg namespace)_interface.launch"/>
     <group ns="$(arg namespace)">
         <node pkg="task_planning" name="single_shot_planner" type="$(arg namespace)_open_loop_planning" output="screen">
@@ -17,6 +18,7 @@
             <param name="goal_x" value="$(arg goal_x)" />
             <param name="goal_y" value="$(arg goal_y)" />
             <param name="planning_cycle_duration" value="$(arg planning_cycle_duration)" />
+            <param name="visualize" value="$(arg visualize)" />
         </node>
         <node pkg="rosbag" name="rosbag_record" type="record" args="-a -O $(find task_planning)/data/$(arg namespace).bag"/>
     </group>

--- a/task_planning/launch/single_shot.launch
+++ b/task_planning/launch/single_shot.launch
@@ -4,6 +4,10 @@
     <arg name = "out_html"  default = "ROS_output.html"/>
     <arg name = "namespace" default = "mushr"/>
     <arg name = "random_seed" default = "0"/>
+    <arg name = "goal_x" default = "3.0"/>
+    <arg name = "goal_y" default = "3.0"/>
+    <arg name = "planning_duration" default = "1.0"/>
+    <arg name = "execution_duration" default = "60.0"/>
     <include file="$(find interface)/launch/$(arg namespace)_interface.launch"/>
     <group ns="$(arg namespace)">
         <node pkg="task_planning" name="single_shot_planner" type="$(arg namespace)_open_loop_planning" output="screen">
@@ -11,6 +15,10 @@
             <param name="plan_file" value="$(arg plan_file)" />
             <param name="out_html"  value="$(arg out_html)" />
             <param name="random_seed" value="$(arg random_seed)" />
+            <param name="goal_x" value="$(arg goal_x)" />
+            <param name="goal_y" value="$(arg goal_y)" />
+            <param name="planning_duration" value="$(arg planning_duration)" />
+            <param name="execution_duration" value="$(arg execution_duration)" />
         </node>
         <node pkg="rosbag" name="rosbag_record" type="record" args="-a -O $(find task_planning)/data/$(arg namespace).bag"/>
     </group>

--- a/task_planning/scripts/mushr_bag_file.py
+++ b/task_planning/scripts/mushr_bag_file.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import rosbag
+import rospkg
+import numpy as np
+# import bagpy
+# from bagpy import bagreader
+
+base_path = rospkg.RosPack().get_path('task_planning') + '/data/'
+namespace = 'mushr'
+rosbag_file = base_path + namespace + ".bag"
+
+ml4kp_plan_file = base_path + namespace + "_plan.txt"
+simulation_trajectory_file = base_path + namespace + "_trajectory.txt"
+
+# b = bagreader(rosbag_file)
+# plan_message = b.message_by_topic('/' + namespace + '/plan')
+# pose_message = b.message_by_topic('/' + namespace + '/pose')
+
+bag = rosbag.Bag(rosbag_file)
+
+topics = ['/' + namespace + '/plan']
+controls = []
+durations = []
+for topic, msg, t in bag.read_messages(topics=topics):
+    for control in msg.controls:
+        controls.append([control.steering_angle.data, control.velocity.data])
+    for duration in msg.durations:
+        durations.append(duration.data.to_sec())
+plans = np.hstack([np.array(controls), np.array(durations)[:, np.newaxis]])
+np.savetxt(ml4kp_plan_file, plans, delimiter=',')
+
+topics = ['/' + namespace + '/pose']
+poses = []
+for topic, msg, t in bag.read_messages(topics=topics):
+    current_pose = [msg.pose.position.x, msg.pose.position.y, msg.pose.position.z, msg.pose.orientation.w, msg.pose.orientation.x, msg.pose.orientation.y, msg.pose.orientation.z]
+    poses.append(current_pose)
+poses = np.array(poses)
+np.savetxt(simulation_trajectory_file, poses, delimiter=',')
+
+bag.close()

--- a/task_planning/src/mushr_open_loop_planning.cpp
+++ b/task_planning/src/mushr_open_loop_planning.cpp
@@ -82,14 +82,13 @@ int main(int argc, char** argv)
   ros::Publisher goal_pos_publisher = n.advertise<geometry_msgs::Pose2D>(root + "/goal_pos", 10, true);
   ros::Publisher goal_radius_publisher = n.advertise<std_msgs::Float64>(root + "/goal_radius", 10, true);
 
-  double planning_duration, execution_duration;
-  n.getParam(ros::this_node::getName() + "/planning_duration", planning_duration);
-  n.getParam(ros::this_node::getName() + "/execution_duration", execution_duration);
+  double planning_cycle_duration;
+  n.getParam(ros::this_node::getName() + "/planning_duration", planning_cycle_duration);
 
   spinner.start();
   goal_pos_publisher.publish(goal_configuration);
   goal_radius_publisher.publish(goal_radius);
-  planner_client.call_service(goal_configuration, goal_radius, planning_duration, execution_duration);
+  planner_client.call_service(goal_configuration, goal_radius, planning_cycle_duration);
 
   ROS_INFO("Preprocess time: %f", planner_service.get_preprocess_time() - planner_client.get_preprocess_time());
   ROS_INFO("Query fulfill time: %f", planner_client.get_query_fulfill_time() - planner_service.get_query_fulfill_time());

--- a/task_planning/src/mushr_open_loop_planning.cpp
+++ b/task_planning/src/mushr_open_loop_planning.cpp
@@ -1,7 +1,7 @@
 #include <ml4kp_bridge/defs.h>
 #include "prx_models/MushrPlanner.h"
 #include "prx_models/mj_mushr.hpp"
-#include "motion_planning/planner_service.hpp"
+#include "motion_planning/single_shot_planner_service.hpp"
 #include "motion_planning/planner_client.hpp"
 
 #include <ros/ros.h>

--- a/task_planning/src/mushr_open_loop_planning.cpp
+++ b/task_planning/src/mushr_open_loop_planning.cpp
@@ -85,7 +85,8 @@ int main(int argc, char** argv)
   ros::Publisher goal_radius_publisher = n.advertise<std_msgs::Float64>(root + "/goal_radius", 10, true);
 
   double planning_cycle_duration;
-  n.getParam(ros::this_node::getName() + "/planning_duration", planning_cycle_duration);
+  n.getParam(ros::this_node::getName() + "/planning_cycle_duration", planning_cycle_duration);
+  ROS_INFO("Planning duration: %f", planning_cycle_duration);
 
   spinner.start();
   goal_pos_publisher.publish(goal_configuration);

--- a/task_planning/src/mushr_open_loop_planning.cpp
+++ b/task_planning/src/mushr_open_loop_planning.cpp
@@ -80,6 +80,9 @@ int main(int argc, char** argv)
   goal_radius_publisher.publish(goal_radius);
   planner_client.call_service(goal_configuration, goal_radius);
 
+  ROS_INFO("Preprocess time: %f", planner_service.get_preprocess_time() - planner_client.get_preprocess_time());
+  ROS_INFO("Query fulfill time: %f", planner_client.get_query_fulfill_time() - planner_service.get_query_fulfill_time());
+
   std::string plan_file_name;
   n.getParam(ros::this_node::getName() + "/plan_file", plan_file_name);
   std::string plan_file_path = ros::package::getPath("task_planning") + "/data/" + plan_file_name;

--- a/task_planning/src/mushr_open_loop_planning.cpp
+++ b/task_planning/src/mushr_open_loop_planning.cpp
@@ -3,6 +3,7 @@
 #include "prx_models/mj_mushr.hpp"
 #include "motion_planning/single_shot_planner_service.hpp"
 #include "motion_planning/planner_client.hpp"
+#include "utils.hpp"
 
 #include <ros/ros.h>
 #include <ros/package.h>
@@ -46,14 +47,14 @@ int main(int argc, char** argv)
   dirt_spec->blossom_number = 25;
   dirt_spec->use_pruning = false;
 
-  double goal_x, goal_y;
-  n.getParam(ros::this_node::getName() + "/goal_x", goal_x);
-  n.getParam(ros::this_node::getName() + "/goal_y", goal_y);
+  std::string goal_config_str;
+  n.getParam(ros::this_node::getName() + "/goal_config", goal_config_str);
+  std::vector<double> goal_config = string_to_vector<double>(goal_config_str, ',');
 
   geometry_msgs::Pose2D goal_configuration;
-  goal_configuration.x = goal_x;
-  goal_configuration.y = goal_y;
-  goal_configuration.theta = 0.0;
+  goal_configuration.x = goal_config[0];
+  goal_configuration.y = goal_config[1];
+  goal_configuration.theta = goal_config[2];
 
   std_msgs::Float64 goal_radius;
   goal_radius.data = 0.25;

--- a/task_planning/src/mushr_open_loop_planning.cpp
+++ b/task_planning/src/mushr_open_loop_planning.cpp
@@ -1,8 +1,8 @@
 #include <ml4kp_bridge/defs.h>
 #include "prx_models/MushrPlanner.h"
+#include "prx_models/mj_mushr.hpp"
 #include "motion_planning/planner_service.hpp"
 #include "motion_planning/planner_client.hpp"
-#include "prx_models/mj_mushr.hpp"
 
 #include <ros/ros.h>
 #include <ros/package.h>
@@ -12,16 +12,17 @@ int main(int argc, char** argv)
 {
   ros::init(argc, argv, "MushrPlanner_example");
   ros::NodeHandle n;
-  prx::simulation_step = 0.1;
-  ROS_WARN("Using simulation step %f", prx::simulation_step);
+  prx::simulation_step = 0.01;
 
   const std::string root{ ros::this_node::getNamespace() };
   int random_seed;
   n.getParam(ros::this_node::getName() + "/random_seed", random_seed);
   prx::init_random(random_seed);
 
-  std::string plant_name = "MushrAnalytical";
-  std::string plant_path = "MushrAnalytical";
+  // std::string plant_name = "MushrAnalytical";
+  // std::string plant_path = "MushrAnalytical";
+  std::string plant_name = "mushr";
+  std::string plant_path = "mushr";
   auto plant = prx::system_factory_t::create_system(plant_name, plant_path);
   prx_assert(plant != nullptr, "Failed to create plant");
 
@@ -30,22 +31,28 @@ int main(int argc, char** argv)
   auto planning_context = planning_model.get_context("planner_context");
   auto ss = planning_context.first->get_state_space();
   auto cs = planning_context.first->get_control_space();
-  std::vector<double> min_control_limits = { -1., -1. };
-  std::vector<double> max_control_limits = { 1., 1. };
+  // std::vector<double> min_control_limits = { -1., -0.5 };
+  // std::vector<double> max_control_limits = { 1., 0.5 };
+  std::vector<double> min_control_limits = { -.5, -1. };
+  std::vector<double> max_control_limits = { .5, 1. };
   cs->set_bounds(min_control_limits, max_control_limits);
 
   std::shared_ptr<prx::dirt_t> dirt = std::make_shared<prx::dirt_t>("dirt");
 
   prx::dirt_specification_t* dirt_spec = new prx::dirt_specification_t(planning_context.first, planning_context.second);
   ROS_WARN("Using defaults for distance function and heuristic");
-  dirt_spec->min_control_steps = 1;
-  dirt_spec->max_control_steps = 25;
+  dirt_spec->min_control_steps = 0.1 * 1.0 / prx::simulation_step;
+  dirt_spec->max_control_steps = 2.0 * 1.0 / prx::simulation_step;
   dirt_spec->blossom_number = 25;
   dirt_spec->use_pruning = false;
 
+  double goal_x, goal_y;
+  n.getParam(ros::this_node::getName() + "/goal_x", goal_x);
+  n.getParam(ros::this_node::getName() + "/goal_y", goal_y);
+
   geometry_msgs::Pose2D goal_configuration;
-  goal_configuration.x = 3.0;
-  goal_configuration.y = -3.0;
+  goal_configuration.x = goal_x;
+  goal_configuration.y = goal_y;
   goal_configuration.theta = 0.0;
 
   std_msgs::Float64 goal_radius;
@@ -75,10 +82,14 @@ int main(int argc, char** argv)
   ros::Publisher goal_pos_publisher = n.advertise<geometry_msgs::Pose2D>(root + "/goal_pos", 10, true);
   ros::Publisher goal_radius_publisher = n.advertise<std_msgs::Float64>(root + "/goal_radius", 10, true);
 
+  double planning_duration, execution_duration;
+  n.getParam(ros::this_node::getName() + "/planning_duration", planning_duration);
+  n.getParam(ros::this_node::getName() + "/execution_duration", execution_duration);
+
   spinner.start();
   goal_pos_publisher.publish(goal_configuration);
   goal_radius_publisher.publish(goal_radius);
-  planner_client.call_service(goal_configuration, goal_radius);
+  planner_client.call_service(goal_configuration, goal_radius, planning_duration, execution_duration);
 
   ROS_INFO("Preprocess time: %f", planner_service.get_preprocess_time() - planner_client.get_preprocess_time());
   ROS_INFO("Query fulfill time: %f", planner_client.get_query_fulfill_time() - planner_service.get_query_fulfill_time());

--- a/task_planning/src/mushr_open_loop_planning.cpp
+++ b/task_planning/src/mushr_open_loop_planning.cpp
@@ -75,10 +75,11 @@ int main(int argc, char** argv)
                                                    prx::dirt_query_t*, prx_models::MushrPlanner>;
   PlannerService planner_service(n, dirt, dirt_spec, dirt_query);
 
-  using PlannerClient =
-      mj_ros::planner_client_t<prx_models::MushrPlanner, prx_models::MushrObservation, ml4kp_bridge::Plan>;
-  PlannerClient planner_client(n);
-
+  bool visualize_trajectory;
+  n.getParam(ros::this_node::getName() + "/visualize", visualize_trajectory);
+  using PlannerClient = mj_ros::planner_client_t<prx_models::MushrPlanner, prx_models::MushrObservation>;
+  PlannerClient planner_client(n, visualize_trajectory);
+  
   ros::Publisher goal_pos_publisher = n.advertise<geometry_msgs::Pose2D>(root + "/goal_pos", 10, true);
   ros::Publisher goal_radius_publisher = n.advertise<std_msgs::Float64>(root + "/goal_radius", 10, true);
 
@@ -91,7 +92,8 @@ int main(int argc, char** argv)
   planner_client.call_service(goal_configuration, goal_radius, planning_cycle_duration);
 
   ROS_INFO("Preprocess time: %f", planner_service.get_preprocess_time() - planner_client.get_preprocess_time());
-  ROS_INFO("Query fulfill time: %f", planner_client.get_query_fulfill_time() - planner_service.get_query_fulfill_time());
+  ROS_INFO("Query fulfill time: %f",
+           planner_client.get_query_fulfill_time() - planner_service.get_query_fulfill_time());
 
   std::string plan_file_name;
   n.getParam(ros::this_node::getName() + "/plan_file", plan_file_name);

--- a/task_planning/src/mushr_replanning.cpp
+++ b/task_planning/src/mushr_replanning.cpp
@@ -74,9 +74,10 @@ int main(int argc, char** argv)
                                                    prx::dirt_query_t*, prx_models::MushrPlanner>;
   PlannerService planner_service(n, dirt, dirt_spec, dirt_query);
 
-  using PlannerClient =
-      mj_ros::planner_client_t<prx_models::MushrPlanner, prx_models::MushrObservation, ml4kp_bridge::Plan>;
-  PlannerClient planner_client(n);
+  bool visualize_trajectory;
+  n.getParam(ros::this_node::getName() + "/visualize", visualize_trajectory);
+  using PlannerClient = mj_ros::planner_client_t<prx_models::MushrPlanner, prx_models::MushrObservation>;
+  PlannerClient planner_client(n, visualize_trajectory);
 
   ros::Publisher goal_pos_publisher = n.advertise<geometry_msgs::Pose2D>(root + "/goal_pos", 10, true);
   ros::Publisher goal_radius_publisher = n.advertise<std_msgs::Float64>(root + "/goal_radius", 10, true);

--- a/task_planning/src/mushr_replanning.cpp
+++ b/task_planning/src/mushr_replanning.cpp
@@ -88,5 +88,16 @@ int main(int argc, char** argv)
   planner_service.set_preprocess_timeout(preprocess_timeout);
   planner_service.set_postprocess_timeout(postprocess_timeout);
 
-  ROS_ERROR("Todo: Implement calling service after checking the step plan implementation");
+  bool first_cycle = true;
+  spinner.start();
+  goal_pos_publisher.publish(goal_configuration);
+  goal_radius_publisher.publish(goal_radius);
+  while (true)
+  {
+    ros::Duration(planning_cycle_duration).sleep();
+    planner_client.call_service(goal_configuration, goal_radius, planning_cycle_duration, first_cycle);
+    first_cycle = false;
+  }
+
+  return 0;
 }

--- a/task_planning/src/mushr_replanning.cpp
+++ b/task_planning/src/mushr_replanning.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
   ros::Publisher goal_radius_publisher = n.advertise<std_msgs::Float64>(root + "/goal_radius", 10, true);
 
   double planning_cycle_duration, preprocess_timeout, postprocess_timeout;
-  n.getParam(ros::this_node::getName() + "/planning_duration", planning_cycle_duration);
+  n.getParam(ros::this_node::getName() + "/planning_cycle_duration", planning_cycle_duration);
   n.getParam(ros::this_node::getName() + "/preprocess_timeout", preprocess_timeout);
   n.getParam(ros::this_node::getName() + "/postprocess_timeout", postprocess_timeout);
   planner_service.set_preprocess_timeout(preprocess_timeout);

--- a/task_planning/src/mushr_replanning.cpp
+++ b/task_planning/src/mushr_replanning.cpp
@@ -3,6 +3,7 @@
 #include "prx_models/mj_mushr.hpp"
 #include "motion_planning/replanner_service.hpp"
 #include "motion_planning/planner_client.hpp"
+#include "utils.hpp"
 
 #include <ros/ros.h>
 #include <ros/package.h>
@@ -16,6 +17,7 @@ int main(int argc, char** argv)
   const std::string root{ ros::this_node::getNamespace() };
   int random_seed;
   n.getParam(ros::this_node::getName() + "/random_seed", random_seed);
+  // TODO: Does this need to be set inside the client/service for better determinism?
   prx::init_random(random_seed);
 
   // std::string plant_name = "MushrAnalytical";
@@ -45,14 +47,14 @@ int main(int argc, char** argv)
   dirt_spec->blossom_number = 25;
   dirt_spec->use_pruning = false;
 
-  double goal_x, goal_y;
-  n.getParam(ros::this_node::getName() + "/goal_x", goal_x);
-  n.getParam(ros::this_node::getName() + "/goal_y", goal_y);
+  std::string goal_config_str;
+  n.getParam(ros::this_node::getName() + "/goal_config", goal_config_str);
+  std::vector<double> goal_config = string_to_vector<double>(goal_config_str, ',');
 
   geometry_msgs::Pose2D goal_configuration;
-  goal_configuration.x = goal_x;
-  goal_configuration.y = goal_y;
-  goal_configuration.theta = 0.0;
+  goal_configuration.x = goal_config[0];
+  goal_configuration.y = goal_config[1];
+  goal_configuration.theta = goal_config[2];
 
   std_msgs::Float64 goal_radius;
   goal_radius.data = 0.25;

--- a/task_planning/src/mushr_replanning.cpp
+++ b/task_planning/src/mushr_replanning.cpp
@@ -1,0 +1,92 @@
+#include <ml4kp_bridge/defs.h>
+#include "prx_models/MushrPlanner.h"
+#include "prx_models/mj_mushr.hpp"
+#include "motion_planning/replanner_service.hpp"
+#include "motion_planning/planner_client.hpp"
+
+#include <ros/ros.h>
+#include <ros/package.h>
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "MushrPlanner_example");
+  ros::NodeHandle n;
+  prx::simulation_step = 0.01;
+
+  const std::string root{ ros::this_node::getNamespace() };
+  int random_seed;
+  n.getParam(ros::this_node::getName() + "/random_seed", random_seed);
+  prx::init_random(random_seed);
+
+  // std::string plant_name = "MushrAnalytical";
+  // std::string plant_path = "MushrAnalytical";
+  std::string plant_name = "mushr";
+  std::string plant_path = "mushr";
+  auto plant = prx::system_factory_t::create_system(plant_name, plant_path);
+  prx_assert(plant != nullptr, "Failed to create plant");
+
+  prx::world_model_t planning_model({ plant }, {});
+  planning_model.create_context("planner_context", { plant_name }, {});
+  auto planning_context = planning_model.get_context("planner_context");
+  auto ss = planning_context.first->get_state_space();
+  auto cs = planning_context.first->get_control_space();
+  // std::vector<double> min_control_limits = { -1., -0.5 };
+  // std::vector<double> max_control_limits = { 1., 0.5 };
+  std::vector<double> min_control_limits = { -.5, -1. };
+  std::vector<double> max_control_limits = { .5, 1. };
+  cs->set_bounds(min_control_limits, max_control_limits);
+
+  std::shared_ptr<prx::dirt_t> dirt = std::make_shared<prx::dirt_t>("dirt");
+
+  prx::dirt_specification_t* dirt_spec = new prx::dirt_specification_t(planning_context.first, planning_context.second);
+  ROS_WARN("Using defaults for distance function and heuristic");
+  dirt_spec->min_control_steps = 0.1 * 1.0 / prx::simulation_step;
+  dirt_spec->max_control_steps = 2.0 * 1.0 / prx::simulation_step;
+  dirt_spec->blossom_number = 25;
+  dirt_spec->use_pruning = false;
+
+  double goal_x, goal_y;
+  n.getParam(ros::this_node::getName() + "/goal_x", goal_x);
+  n.getParam(ros::this_node::getName() + "/goal_y", goal_y);
+
+  geometry_msgs::Pose2D goal_configuration;
+  goal_configuration.x = goal_x;
+  goal_configuration.y = goal_y;
+  goal_configuration.theta = 0.0;
+
+  std_msgs::Float64 goal_radius;
+  goal_radius.data = 0.25;
+
+  prx::dirt_query_t* dirt_query = new prx::dirt_query_t(ss, cs);
+  dirt_query->start_state = ss->make_point();
+  dirt_query->goal_state = ss->make_point();
+  dirt_query->goal_region_radius = goal_radius.data;
+  dirt_query->get_visualization = true;
+  ROS_WARN("Using default goal check");
+
+  dirt->link_and_setup_spec(dirt_spec);
+  dirt->preprocess();
+  dirt->link_and_setup_query(dirt_query);
+
+  ros::AsyncSpinner spinner(2);
+
+  using PlannerService = mj_ros::planner_service_t<std::shared_ptr<prx::dirt_t>, prx::dirt_specification_t*,
+                                                   prx::dirt_query_t*, prx_models::MushrPlanner>;
+  PlannerService planner_service(n, dirt, dirt_spec, dirt_query);
+
+  using PlannerClient =
+      mj_ros::planner_client_t<prx_models::MushrPlanner, prx_models::MushrObservation, ml4kp_bridge::Plan>;
+  PlannerClient planner_client(n);
+
+  ros::Publisher goal_pos_publisher = n.advertise<geometry_msgs::Pose2D>(root + "/goal_pos", 10, true);
+  ros::Publisher goal_radius_publisher = n.advertise<std_msgs::Float64>(root + "/goal_radius", 10, true);
+
+  double planning_cycle_duration, preprocess_timeout, postprocess_timeout;
+  n.getParam(ros::this_node::getName() + "/planning_duration", planning_cycle_duration);
+  n.getParam(ros::this_node::getName() + "/preprocess_timeout", preprocess_timeout);
+  n.getParam(ros::this_node::getName() + "/postprocess_timeout", postprocess_timeout);
+  planner_service.set_preprocess_timeout(preprocess_timeout);
+  planner_service.set_postprocess_timeout(postprocess_timeout);
+
+  ROS_ERROR("Todo: Implement calling service after checking the step plan implementation");
+}

--- a/world/mujoco_ros/include/mujoco_ros/simulator.hpp
+++ b/world/mujoco_ros/include/mujoco_ros/simulator.hpp
@@ -242,6 +242,19 @@ public:
         double linewidth = 3.0;
         double lineheight = 0.1;
         int step = 10;
+        // Plot start state as a small sphere
+        mjvGeom* start_geom = scn.geoms + scn.ngeom++;
+        mjv_initGeom(start_geom, mjGEOM_SPHERE, NULL, NULL, NULL, NULL);
+        start_geom->rgba[0] = 1.0;
+        start_geom->rgba[1] = 0.0;
+        start_geom->rgba[2] = 0.0;
+        start_geom->rgba[3] = 0.5;
+        start_geom->size[0] = 0.05;
+        start_geom->size[1] = 0.05;
+        start_geom->size[2] = 0.05;
+        start_geom->pos[0] = trajectory_to_visualize[0][0];
+        start_geom->pos[1] = trajectory_to_visualize[0][1];
+        start_geom->pos[2] = lineheight;
         for (int i = step; i < trajectory_to_visualize.size(); i+=step)
         {
           if (scn.ngeom >= scn.maxgeom)

--- a/world/mujoco_ros/launch/mushr.launch
+++ b/world/mujoco_ros/launch/mushr.launch
@@ -1,11 +1,11 @@
 <launch>
     <param name="model_path" type="string" value="$(find prx_models)/models/mushr/mushr.xml"/>
-    <param name="save_trajectory" type="bool" value="false"/>
+    <arg name="save_trajectory" default="false"/>
     <arg name="visualize" default="true"/>
     <group ns="mushr">
         <node pkg="mujoco_ros" name="simulation" type="mushr_simulation" output="screen">
             <param name="visualize" value="$(arg visualize)" />
-            <param name="save_trajectory" value="$(arg visualize)" />
+            <param name="save_trajectory" value="$(arg save_trajectory)" />
         </node>
     </group>
 </launch>

--- a/world/mujoco_ros/launch/mushr.launch
+++ b/world/mujoco_ros/launch/mushr.launch
@@ -1,8 +1,10 @@
 <launch>
+    <arg name = "namespace" default = "mushr"/>
     <param name="model_path" type="string" value="$(find prx_models)/models/mushr/mushr.xml"/>
     <arg name="save_trajectory" default="false"/>
     <arg name="visualize" default="true"/>
-    <group ns="mushr">
+    <include file="$(find interface)/launch/$(arg namespace)_interface.launch"/>
+    <group ns="$(arg namespace)">
         <node pkg="mujoco_ros" name="simulation" type="mushr_simulation" output="screen">
             <param name="visualize" value="$(arg visualize)" />
             <param name="save_trajectory" value="$(arg save_trajectory)" />

--- a/world/mujoco_ros/launch/mushr_execute_plan.launch
+++ b/world/mujoco_ros/launch/mushr_execute_plan.launch
@@ -4,8 +4,9 @@
     <arg name="delimiter" default=","/>
     <arg name="save_trajectory" default="false"/>
     <arg name="visualize" default="true"/>
-    <arg name "trajectory_output_file" default="data/mushr_trajectory.txt"/>
-    <group ns="mushr">
+    <arg name = "namespace" default = "mushr"/>
+    <arg name="trajectory_output_file" default="data/mushr_trajectory.txt"/>
+    <group ns="$(arg namespace)">
         <node pkg="mujoco_ros" name="mushr_simulation" type="mushr_simulation" output="screen">
             <param name="visualize" value="$(arg visualize)" />
             <param name="save_trajectory" value="$(arg save_trajectory)" />
@@ -15,5 +16,6 @@
             <param name="plan_file" value="$(arg plan_file)" />
             <param name="delimiter" value="$(arg delimiter)" />
         </node>
+        <node pkg="rosbag" name="rosbag_record" type="record" args="-a -O $(find mujoco_ros)/data/$(arg namespace).bag"/>
     </group>
 </launch>

--- a/world/mujoco_ros/launch/mushr_execute_plan.launch
+++ b/world/mujoco_ros/launch/mushr_execute_plan.launch
@@ -4,10 +4,12 @@
     <arg name="delimiter" default=","/>
     <arg name="save_trajectory" default="false"/>
     <arg name="visualize" default="true"/>
+    <arg name "trajectory_output_file" default="data/mushr_trajectory.txt"/>
     <group ns="mushr">
         <node pkg="mujoco_ros" name="mushr_simulation" type="mushr_simulation" output="screen">
             <param name="visualize" value="$(arg visualize)" />
             <param name="save_trajectory" value="$(arg save_trajectory)" />
+            <param name="trajectory_output_file" value="$(arg trajectory_output_file)" />
         </node>
         <node pkg="mujoco_ros" name="open_loop_publisher" type="mushr_open_loop_publisher.py" output="screen">
             <param name="plan_file" value="$(arg plan_file)" />

--- a/world/mujoco_ros/launch/mushr_open_loop.launch
+++ b/world/mujoco_ros/launch/mushr_open_loop.launch
@@ -3,9 +3,10 @@
     <arg name="plan_file" default="data/mushr_plan.txt"/>
     <arg name="delimiter" default=","/>
     <arg name="save_trajectory" default="false"/>
+    <arg name="visualize" default="true"/>
     <group ns="mushr">
-        <node pkg="mujoco_ros" name="mushr_visualize" type="mushr_visualize" output="screen">
-            <param name="visualize" value="true" />
+        <node pkg="mujoco_ros" name="mushr_simulation" type="mushr_simulation" output="screen">
+            <param name="visualize" value="$(arg visualize)" />
             <param name="save_trajectory" value="$(arg save_trajectory)" />
         </node>
         <node pkg="mujoco_ros" name="open_loop_publisher" type="mushr_open_loop_publisher.py" output="screen">

--- a/world/mujoco_ros/scripts/mushr_open_loop_publisher.py
+++ b/world/mujoco_ros/scripts/mushr_open_loop_publisher.py
@@ -5,7 +5,7 @@ import numpy as np
 import rospkg
 import os
 from prx_models.msg import MushrPlan, MushrControl
-from std_msgs.msg import Float64
+from std_msgs.msg import Duration
 
 def talker():
     rospy.init_node('mushr_open_loop_publisher', anonymous=True)
@@ -31,13 +31,13 @@ def talker():
         ctrl.steering_angle.data = float(plan[i, 0])
         ctrl.velocity.data = float(plan[i, 1])
         msg.controls.append(ctrl)
-        msg.durations.append(Float64(float(plan[i, 2])))
+        msg.durations.append(Duration(rospy.Duration.from_sec(plan[i, 2])))
     
     ctrl = MushrControl()
     ctrl.steering_angle.data = 0.0
     ctrl.velocity.data = 0.0
     msg.controls.append(ctrl)
-    msg.durations.append(Float64(0.0))
+    msg.durations.append(Duration(rospy.Duration.from_sec(0.0)))
     # print(msg)
     pub.publish(msg)
     # rate.sleep()

--- a/world/mujoco_ros/src/mushr_simulation.cpp
+++ b/world/mujoco_ros/src/mushr_simulation.cpp
@@ -39,8 +39,8 @@ int main(int argc, char** argv)
   controller_listener_t<CtrlMsg, PlanMsg> controller_listener(n, sim->d);
   mj_ros::sensordata_publisher_t sensordata_publisher(n, sim, 15);
 
-  ros::Subscriber reset_subscriber;
-  reset_subscriber = n.subscribe(root + "/reset", 1000, &mj_ros::simulator_t::reset_simulation, sim.get());
+  ros::Subscriber reset_subscriber_for_sim, reset_subscriber_for_viz;
+  reset_subscriber_for_sim = n.subscribe(root + "/reset", 1000, &mj_ros::simulator_t::reset_simulation, sim.get());
 
   // Set the threads
   std::thread step_thread(&mj_ros::simulator_t::run, &(*sim));  // Mj sim
@@ -57,9 +57,10 @@ int main(int argc, char** argv)
         n.subscribe(root + "/goal_pos", 1000, &mj_ros::simulator_visualizer_t::set_goal_pos, visualizer.get());
     goal_radius_subscriber =
         n.subscribe(root + "/goal_radius", 1000, &mj_ros::simulator_visualizer_t::set_goal_radius, visualizer.get());
-    // Is this ok for this to subscribe directly to ml4kp_traj?
+    // TODO: Is this ok for this to subscribe directly to ml4kp_traj?
     trajectory_subscriber = n.subscribe(root + "/ml4kp_traj", 1000,
-                                        &mj_ros::simulator_visualizer_t::set_trajectory_to_visualize, visualizer.get());
+                                          &mj_ros::simulator_visualizer_t::set_trajectory_to_visualize, visualizer.get());
+    reset_subscriber_for_viz = n.subscribe(root + "/reset", 1000, &mj_ros::simulator_visualizer_t::reset, visualizer.get());
   }
 
   // Run threads: Mj sim is already running at this point

--- a/world/mujoco_ros/src/mushr_simulation.cpp
+++ b/world/mujoco_ros/src/mushr_simulation.cpp
@@ -50,13 +50,16 @@ int main(int argc, char** argv)
     visualizer = std::make_shared<mj_ros::simulator_visualizer_t>(sim);
   ros::AsyncSpinner spinner(1);  // 1 thread for the controller
 
-  ros::Subscriber goal_pos_subscriber, goal_radius_subscriber;
+  ros::Subscriber goal_pos_subscriber, goal_radius_subscriber, trajectory_subscriber;
   if (visualize)
   {
     goal_pos_subscriber =
         n.subscribe(root + "/goal_pos", 1000, &mj_ros::simulator_visualizer_t::set_goal_pos, visualizer.get());
     goal_radius_subscriber =
         n.subscribe(root + "/goal_radius", 1000, &mj_ros::simulator_visualizer_t::set_goal_radius, visualizer.get());
+    // Is this ok for this to subscribe directly to ml4kp_traj?
+    trajectory_subscriber = n.subscribe(root + "/ml4kp_traj", 1000,
+                                        &mj_ros::simulator_visualizer_t::set_trajectory_to_visualize, visualizer.get());
   }
 
   // Run threads: Mj sim is already running at this point


### PR DESCRIPTION
Added a first draft of replanning. It would be good to review what's already here.

As mentioned on Zulip, we will need the following functionality before merging:

* In the _first_ planning cycle, we need to take the ML4KP plan and split it into three: the first two chunks are of length $t_\text{plan}$ each, and the rest. The rest can be discarded (not sent to the topic).
* For subsequent planning cycles, we need to split the ML4KP plan into two: the first chunk is of length $t_\text{plan}$, and the rest. The rest is discarded.
* Every time `planner_service_t` is called, it needs the `step_plan` for the next iteration so this can be propagated from the most current observation to get the start state of the next planning cycle.