### PR TITLE
SpacePoint msg change from "std_msgs/Float64[]" to "Float64" aka double.

### DIFF
--- a/estimation/src/nodelets/aruco_wTc.cpp
+++ b/estimation/src/nodelets/aruco_wTc.cpp
@@ -130,7 +130,7 @@ private:
     for (auto& state : message->trajectory.data)
     {
       // x,y,z: setting z=0 for now
-      _cv_traj.emplace_back(state.point[0].data, state.point[1].data, 0.0);
+      _cv_traj.emplace_back(state.point[0], state.point[1], 0.0);
       _msgs_received[PointIdx::trajectory] = true;
     }
     cv::projectPoints(_cv_traj, _Rvec, _Tvec, _camera_matrix, _dist_coeffs, _image_traj);

--- a/infrastructure/interface/include/interface/ackermann_msg.hpp
+++ b/infrastructure/interface/include/interface/ackermann_msg.hpp
@@ -10,7 +10,7 @@ inline void translate_msg(ackermann_msgs::AckermannDriveStamped& ctrl_msg, const
 {
   using prx_models::mushr_t::control::steering_idx;
   using prx_models::mushr_t::control::velocity_idx;
-  ctrl_msg.drive.steering_angle = point_msg.point[steering_idx].data;
-  ctrl_msg.drive.speed = point_msg.point[velocity_idx].data;
+  ctrl_msg.drive.steering_angle = point_msg.point[steering_idx];
+  ctrl_msg.drive.speed = point_msg.point[velocity_idx];
 }
 }  // namespace interface

--- a/infrastructure/interface/include/interface/mushr_translation.hpp
+++ b/infrastructure/interface/include/interface/mushr_translation.hpp
@@ -9,8 +9,8 @@ inline void translate_msg(prx_models::MushrControl& ctrl_msg, const ml4kp_bridge
 {
   using prx_models::mushr_t::control::steering_idx;
   using prx_models::mushr_t::control::velocity_idx;
-  ctrl_msg.steering_angle.data = point_msg.point[steering_idx].data;
-  ctrl_msg.velocity.data = point_msg.point[velocity_idx].data;
+  ctrl_msg.steering_angle.data = point_msg.point[steering_idx];
+  ctrl_msg.velocity.data = point_msg.point[velocity_idx];
 }
 
 inline void translate_msg(prx_models::MushrPlan& mushr_plan, const ml4kp_bridge::PlanStamped& stamped_plan)
@@ -23,8 +23,8 @@ inline void translate_msg(prx_models::MushrPlan& mushr_plan, const ml4kp_bridge:
   {
     const ml4kp_bridge::PlanStep plan_step{ stamped_plan.plan.steps[i] };
     // copy(mushr_plan.controls[i], plan_step.control.state);
-    mushr_plan.controls[i].velocity.data = plan_step.control.point[0].data;
-    mushr_plan.controls[i].steering_angle.data = plan_step.control.point[1].data;
+    mushr_plan.controls[i].velocity.data = plan_step.control.point[0];
+    mushr_plan.controls[i].steering_angle.data = plan_step.control.point[1];
     mushr_plan.durations[i] = stamped_plan.plan.steps[i].duration;
   }
 }

--- a/infrastructure/interface/tests/msg_translation.cpp
+++ b/infrastructure/interface/tests/msg_translation.cpp
@@ -18,10 +18,10 @@ TEST(TranslateMsg, test_mushr_plan_from_ml4kp_bridge_plan)
   stamped_plan.plan.steps[0].control.point.resize(u_dim);
   stamped_plan.plan.steps[1].control.point.resize(u_dim);
 
-  stamped_plan.plan.steps[0].control.point[0].data = 1.0;
-  stamped_plan.plan.steps[0].control.point[1].data = 1.5;
-  stamped_plan.plan.steps[1].control.point[0].data = 2.0;
-  stamped_plan.plan.steps[1].control.point[1].data = 2.5;
+  stamped_plan.plan.steps[0].control.point[0] = 1.0;
+  stamped_plan.plan.steps[0].control.point[1] = 1.5;
+  stamped_plan.plan.steps[1].control.point[0] = 2.0;
+  stamped_plan.plan.steps[1].control.point[1] = 2.5;
 
   interface::translate_msg(mushr_plan, stamped_plan);
 

--- a/infrastructure/ml4kp_bridge/include/ml4kp_bridge/space_bridge.hpp
+++ b/infrastructure/ml4kp_bridge/include/ml4kp_bridge/space_bridge.hpp
@@ -11,7 +11,7 @@ inline void copy(ml4kp_bridge::SpacePoint& msg, const prx::space_snapshot_t& sta
   msg.point.resize(state.size());
   for (std::size_t i = 0; i < msg.point.size(); ++i)
   {
-    msg.point[i].data = state[i];
+    msg.point[i] = state[i];
   }
 }
 
@@ -27,7 +27,7 @@ inline void copy(prx::space_snapshot_t& state, const ml4kp_bridge::SpacePoint& m
   ROS_ASSERT(state.size() == msg.point.size());
   for (std::size_t i = 0; i < msg.point.size(); ++i)
   {
-    state[i] = msg.point[i].data;
+    state[i] = msg.point[i];
   }
 }
 

--- a/infrastructure/ml4kp_bridge/msg/SpacePoint.msg
+++ b/infrastructure/ml4kp_bridge/msg/SpacePoint.msg
@@ -1,1 +1,1 @@
-std_msgs/Float64[] point
+float64[] point

--- a/infrastructure/ml4kp_bridge/tests/msgs_utils.cpp
+++ b/infrastructure/ml4kp_bridge/tests/msgs_utils.cpp
@@ -37,9 +37,9 @@ TEST(SpaceBridge, test_copy_msg_from_state)
 
   ml4kp_bridge::copy(msg, state);
 
-  ASSERT_DOUBLE_EQ(1.0, msg.space_point.point[0].data);
-  ASSERT_DOUBLE_EQ(2.0, msg.space_point.point[1].data);
-  ASSERT_DOUBLE_EQ(3.1415, msg.space_point.point[2].data);
+  ASSERT_DOUBLE_EQ(1.0, msg.space_point.point[0]);
+  ASSERT_DOUBLE_EQ(2.0, msg.space_point.point[1]);
+  ASSERT_DOUBLE_EQ(3.1415, msg.space_point.point[2]);
   ASSERT_LT(0, msg.header.seq);
   ASSERT_LT(msg.header.stamp, ros::Time::now());  // stamp <= now
 };
@@ -55,9 +55,9 @@ TEST(SpaceBridge, test_copy_state_from_msg)
   msg.header.seq = 10;
   msg.header.stamp = ros::Time::now();
   msg.space_point.point.resize(3);
-  msg.space_point.point[0].data = 1;
-  msg.space_point.point[1].data = 2;
-  msg.space_point.point[2].data = 3.1415;
+  msg.space_point.point[0] = 1;
+  msg.space_point.point[1] = 2;
+  msg.space_point.point[2] = 3.1415;
   ml4kp_bridge::copy(state, msg);
 
   ASSERT_DOUBLE_EQ(1.0, state->at(0));
@@ -82,13 +82,13 @@ TEST(TrajectoryBridge, test_copy_msg_from_trajectory)
 
   ml4kp_bridge::copy(msg, trajectory);
 
-  ASSERT_DOUBLE_EQ(1.0, msg.trajectory.data[0].point[0].data);
-  ASSERT_DOUBLE_EQ(1.0, msg.trajectory.data[0].point[1].data);
-  ASSERT_DOUBLE_EQ(1.0, msg.trajectory.data[0].point[2].data);
+  ASSERT_DOUBLE_EQ(1.0, msg.trajectory.data[0].point[0]);
+  ASSERT_DOUBLE_EQ(1.0, msg.trajectory.data[0].point[1]);
+  ASSERT_DOUBLE_EQ(1.0, msg.trajectory.data[0].point[2]);
 
-  ASSERT_DOUBLE_EQ(2.0, msg.trajectory.data[1].point[0].data);
-  ASSERT_DOUBLE_EQ(2.0, msg.trajectory.data[1].point[1].data);
-  ASSERT_DOUBLE_EQ(2.0, msg.trajectory.data[1].point[2].data);
+  ASSERT_DOUBLE_EQ(2.0, msg.trajectory.data[1].point[0]);
+  ASSERT_DOUBLE_EQ(2.0, msg.trajectory.data[1].point[1]);
+  ASSERT_DOUBLE_EQ(2.0, msg.trajectory.data[1].point[2]);
 
   ASSERT_LT(0, msg.header.seq);
   ASSERT_LT(msg.header.stamp, ros::Time::now());  // stamp <= now
@@ -107,12 +107,12 @@ TEST(TrajectoryBridge, test_copy_trajectory_from_msg)
   ml4kp_bridge::SpacePoint pt1{};
   pt0.point.resize(3);
   pt1.point.resize(3);
-  pt0.point[0].data = 1;
-  pt0.point[1].data = 1;
-  pt0.point[2].data = 1;
-  pt1.point[0].data = 2;
-  pt1.point[1].data = 2;
-  pt1.point[2].data = 2;
+  pt0.point[0] = 1;
+  pt0.point[1] = 1;
+  pt0.point[2] = 1;
+  pt1.point[0] = 2;
+  pt1.point[1] = 2;
+  pt1.point[2] = 2;
   msg.trajectory.data.push_back(pt0);
   msg.trajectory.data.push_back(pt1);
 
@@ -144,9 +144,9 @@ TEST(PlanStepBridge, test_copy_msg_from_plan_step)
 
   ml4kp_bridge::copy(msg, plan_step);
 
-  ASSERT_DOUBLE_EQ(msg.plan_step.control.point[0].data, 1.0);
-  ASSERT_DOUBLE_EQ(msg.plan_step.control.point[1].data, 2.0);
-  ASSERT_DOUBLE_EQ(msg.plan_step.control.point[2].data, 3.0);
+  ASSERT_DOUBLE_EQ(msg.plan_step.control.point[0], 1.0);
+  ASSERT_DOUBLE_EQ(msg.plan_step.control.point[1], 2.0);
+  ASSERT_DOUBLE_EQ(msg.plan_step.control.point[2], 3.0);
   ASSERT_LT(msg.header.stamp, ros::Time::now());  // stamp <= now
 };
 
@@ -163,9 +163,9 @@ TEST(PlanStepBridge, test_copy_plan_step_from_msg)
   ml4kp_bridge::PlanStepStamped msg;
 
   msg.plan_step.control.point.resize(3);
-  msg.plan_step.control.point[0].data = 1.0;
-  msg.plan_step.control.point[1].data = 2.0;
-  msg.plan_step.control.point[2].data = 3.0;
+  msg.plan_step.control.point[0] = 1.0;
+  msg.plan_step.control.point[1] = 2.0;
+  msg.plan_step.control.point[2] = 3.0;
 
   ml4kp_bridge::copy(plan_step, msg);
 
@@ -194,12 +194,12 @@ TEST(PlanBridge, test_copy_msg_from_plan)
 
   ml4kp_bridge::copy(msg, plan);
 
-  ASSERT_DOUBLE_EQ(msg.plan.steps[0].control.point[0].data, 1.0);
-  ASSERT_DOUBLE_EQ(msg.plan.steps[0].control.point[1].data, 1.0);
-  ASSERT_DOUBLE_EQ(msg.plan.steps[0].control.point[2].data, 1.0);
-  ASSERT_DOUBLE_EQ(msg.plan.steps[1].control.point[0].data, 2.0);
-  ASSERT_DOUBLE_EQ(msg.plan.steps[1].control.point[1].data, 2.0);
-  ASSERT_DOUBLE_EQ(msg.plan.steps[1].control.point[2].data, 2.0);
+  ASSERT_DOUBLE_EQ(msg.plan.steps[0].control.point[0], 1.0);
+  ASSERT_DOUBLE_EQ(msg.plan.steps[0].control.point[1], 1.0);
+  ASSERT_DOUBLE_EQ(msg.plan.steps[0].control.point[2], 1.0);
+  ASSERT_DOUBLE_EQ(msg.plan.steps[1].control.point[0], 2.0);
+  ASSERT_DOUBLE_EQ(msg.plan.steps[1].control.point[1], 2.0);
+  ASSERT_DOUBLE_EQ(msg.plan.steps[1].control.point[2], 2.0);
   ASSERT_LT(msg.header.stamp, ros::Time::now());  // stamp <= now
 };
 
@@ -214,12 +214,12 @@ TEST(PlanBridge, test_copy_plan_from_msg)
   msg.plan.steps.resize(2);
   msg.plan.steps[0].control.point.resize(3);
   msg.plan.steps[1].control.point.resize(3);
-  msg.plan.steps[0].control.point[0].data = 1.0;
-  msg.plan.steps[0].control.point[1].data = 1.0;
-  msg.plan.steps[0].control.point[2].data = 1.0;
-  msg.plan.steps[1].control.point[0].data = 2.0;
-  msg.plan.steps[1].control.point[1].data = 2.0;
-  msg.plan.steps[1].control.point[2].data = 2.0;
+  msg.plan.steps[0].control.point[0] = 1.0;
+  msg.plan.steps[0].control.point[1] = 1.0;
+  msg.plan.steps[0].control.point[2] = 1.0;
+  msg.plan.steps[1].control.point[0] = 2.0;
+  msg.plan.steps[1].control.point[1] = 2.0;
+  msg.plan.steps[1].control.point[2] = 2.0;
 
   ml4kp_bridge::copy(plan, msg);
 
@@ -234,6 +234,41 @@ TEST(PlanBridge, test_copy_plan_from_msg)
   ASSERT_DOUBLE_EQ(plan[idx].control->at(2), 2.0);
   ASSERT_LT(msg.header.stamp, ros::Time::now());  // stamp <= now
 };
+
+TEST(SpacePointMsg, test_copy_point_to_msg_through_space)
+{
+  mock::space3d_t test;
+  prx::space_t& space{ test._space };
+
+  prx::space_point_t state{ space.make_point() };
+  ml4kp_bridge::SpacePoint msg;
+  msg.point.resize(state->size());
+
+  Vec(state) = Eigen::Vector<double, 3>(1.0, 2.0, 3.0);
+  space.copy(msg.point, state);
+
+  ASSERT_DOUBLE_EQ(msg.point[0], 1.0);
+  ASSERT_DOUBLE_EQ(msg.point[1], 2.0);
+  ASSERT_DOUBLE_EQ(msg.point[2], 3.0);
+}
+
+TEST(SpacePointMsg, test_copy_point_from_msg_through_space)
+{
+  mock::space3d_t test;
+  prx::space_t& space{ test._space };
+
+  prx::space_point_t state{ space.make_point() };
+  ml4kp_bridge::SpacePoint msg;
+  msg.point.resize(state->size());
+  msg.point[0] = 1.0;
+  msg.point[1] = 2.0;
+  msg.point[2] = 3.0;
+  space.copy(state, msg.point);
+
+  ASSERT_DOUBLE_EQ(Vec(state)[0], 1.0);
+  ASSERT_DOUBLE_EQ(Vec(state)[1], 2.0);
+  ASSERT_DOUBLE_EQ(Vec(state)[2], 3.0);
+}
 
 int main(int argc, char** argv)
 {

--- a/world/mujoco_ros/include/mujoco_ros/simulator.hpp
+++ b/world/mujoco_ros/include/mujoco_ros/simulator.hpp
@@ -322,13 +322,7 @@ public:
     const std::vector<ml4kp_bridge::SpacePoint>& points = msg.data;
     for (const auto& point : points)
     {
-      const std::vector<std_msgs::Float64>& values = point.point;
-      std::vector<double> point_to_add;
-      for (const auto& value : values)
-      {
-        point_to_add.push_back(value.data);
-      }
-      trajectory_to_visualize.push_back(point_to_add);
+      trajectory_to_visualize.emplace_back(point.point);
     }
   }
 


### PR DESCRIPTION
This allows to copy points directly with space_t.
Changes where needed.